### PR TITLE
IP was always 127.0.0.1 in log

### DIFF
--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -48,6 +48,12 @@ http {
 	gzip_comp_level 	3;
 	gzip_proxied 		any;
 	gzip_buffers 		16 8k;
+	
+	# Put the Ip of your varnish/proxy here
+	set_real_ip_from   127.0.0.1; 
+	# Put the Header that your varnish/proxy set
+        real_ip_header      X-Forwarded-For;
+
 
 	include /etc/nginx/conf.d/*.conf;
 	include /etc/nginx/sites-enabled/*;


### PR DESCRIPTION
In my log, requests IP was always set to 127.0.0.1. This is caused by varnish who was on the same machine as nginx.
With that fix, IP is set correctly to the client's IP.

Source : http://linuxaria.com/article/how-to-log-the-correct-ip-having-varnish-and-nginx